### PR TITLE
Fix concurrent tuple ToString & GetEnumerator

### DIFF
--- a/src/OrleanSpaces/Helpers/TemplateHelpers.cs
+++ b/src/OrleanSpaces/Helpers/TemplateHelpers.cs
@@ -58,5 +58,5 @@ internal static class TemplateHelpers
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string ToString<T>(T?[] fields) where T : unmanaged
-        => $"({string.Join(", ", fields.Select(field => field is null ? "{NULL}" : field.ToString()))})";
+        => fields is null ? "()" : $"({string.Join(", ", fields.Select(field => field is null ? "{NULL}" : field.ToString()))})";
 }

--- a/src/OrleanSpaces/Helpers/TupleHelpers.cs
+++ b/src/OrleanSpaces/Helpers/TupleHelpers.cs
@@ -244,5 +244,5 @@ internal static class TupleHelpers
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string ToString<T>(T[] fields) where T : unmanaged
-        => $"({string.Join(", ", fields)})";
+        => fields is null ? "()" : $"({string.Join(", ", fields)})";
 }

--- a/src/OrleanSpaces/Tuples/SpaceTuple.cs
+++ b/src/OrleanSpaces/Tuples/SpaceTuple.cs
@@ -102,13 +102,14 @@ public readonly record struct SpaceTuple :
         return true;
     }
 
-    public override int GetHashCode() => fields.GetHashCode();
-    public override string ToString() => $"({string.Join(", ", fields)})";
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
+    public override string ToString() => $"({string.Join(", ", fields ?? Array.Empty<object>())})";
 
     /// <summary>
     /// Returns an enumerator to enumerate over the fields of this tuple.
     /// </summary>
-    public ReadOnlySpan<object>.Enumerator GetEnumerator() => new ReadOnlySpan<object>(fields).GetEnumerator();
+    public ReadOnlySpan<object>.Enumerator GetEnumerator() =>
+        (fields is null ? ReadOnlySpan<object>.Empty : new ReadOnlySpan<object>(fields)).GetEnumerator();
 }
 
 /// <summary>
@@ -224,11 +225,12 @@ public readonly record struct SpaceTemplate :
         return true;
     }
 
-    public override int GetHashCode() => fields.GetHashCode();
-    public override string ToString() => $"({string.Join(", ", fields.Select(field => field ?? "{NULL}"))})";
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
+    public override string ToString() => fields is null ? "()" : $"({string.Join(", ", fields.Select(field => field ?? "{NULL}"))})";
 
     /// <summary>
     /// Returns an enumerator to enumerate over the fields of this tuple.
     /// </summary>
-    public ReadOnlySpan<object?>.Enumerator GetEnumerator() => new ReadOnlySpan<object?>(fields).GetEnumerator();
+    public ReadOnlySpan<object?>.Enumerator GetEnumerator() =>
+        (fields is null ? ReadOnlySpan<object?>.Empty : new ReadOnlySpan<object?>(fields)).GetEnumerator();
 }

--- a/src/OrleanSpaces/Tuples/Specialized/BoolTuple.cs
+++ b/src/OrleanSpaces/Tuples/Specialized/BoolTuple.cs
@@ -55,12 +55,13 @@ public readonly record struct BoolTuple :
         return marshaller.TryParallelEquals(out bool result) ? result : this.SequentialEquals<bool, BoolTuple>(other);
     }
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TupleHelpers.ToString(fields);
 
     static BoolTuple ISpaceFactory<bool, BoolTuple>.Create(bool[] fields) => new(fields);
 
-    public ReadOnlySpan<bool>.Enumerator GetEnumerator() => new ReadOnlySpan<bool>(fields).GetEnumerator();
+    public ReadOnlySpan<bool>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<bool>.Empty : new ReadOnlySpan<bool>(fields)).GetEnumerator();
 
     public ReadOnlySpan<char> AsSpan()
     {
@@ -131,8 +132,9 @@ public readonly record struct BoolTemplate :
     public bool Matches(BoolTuple tuple) => this.Matches<bool, BoolTuple, BoolTemplate>(tuple);
     public bool Equals(BoolTemplate other) => this.SequentialEquals<bool, BoolTemplate>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TemplateHelpers.ToString(fields);
 
-    public ReadOnlySpan<bool?>.Enumerator GetEnumerator() => new ReadOnlySpan<bool?>(fields).GetEnumerator();
+    public ReadOnlySpan<bool?>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<bool?>.Empty : new ReadOnlySpan<bool?>(fields)).GetEnumerator();
 }

--- a/src/OrleanSpaces/Tuples/Specialized/ByteTuple.cs
+++ b/src/OrleanSpaces/Tuples/Specialized/ByteTuple.cs
@@ -55,13 +55,14 @@ public readonly record struct ByteTuple :
         => this.TryParallelEquals<byte, ByteTuple>(other, out bool result) ? 
                result : this.SequentialEquals<byte, ByteTuple>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TupleHelpers.ToString(fields);
 
     static ByteTuple ISpaceFactory<byte, ByteTuple>.Create(byte[] fields) => new(fields);
 
     public ReadOnlySpan<char> AsSpan() => this.AsSpan<byte, ByteTuple>(Constants.MaxFieldCharLength_Byte);
-    public ReadOnlySpan<byte>.Enumerator GetEnumerator() => new ReadOnlySpan<byte>(fields).GetEnumerator();
+    public ReadOnlySpan<byte>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<byte>.Empty : new ReadOnlySpan<byte>(fields)).GetEnumerator();
 }
 
 /// <summary>
@@ -98,8 +99,9 @@ public readonly record struct ByteTemplate :
     public bool Matches(ByteTuple tuple) => this.Matches<byte, ByteTuple, ByteTemplate>(tuple);
     public bool Equals(ByteTemplate other) => this.SequentialEquals<byte, ByteTemplate>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TemplateHelpers.ToString(fields);
     
-    public ReadOnlySpan<byte?>.Enumerator GetEnumerator() => new ReadOnlySpan<byte?>(fields).GetEnumerator();
+    public ReadOnlySpan<byte?>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<byte?>.Empty : new ReadOnlySpan<byte?>(fields)).GetEnumerator();
 }

--- a/src/OrleanSpaces/Tuples/Specialized/CharTuple.cs
+++ b/src/OrleanSpaces/Tuples/Specialized/CharTuple.cs
@@ -66,13 +66,14 @@ public readonly record struct CharTuple :
                    result : this.SequentialEquals<char, CharTuple>(other);
     }
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TupleHelpers.ToString(fields);
 
     static CharTuple ISpaceFactory<char, CharTuple>.Create(char[] fields) => new(fields);
 
     public ReadOnlySpan<char> AsSpan() => this.AsSpan<char, CharTuple>(Constants.MaxFieldCharLength_Char);
-    public ReadOnlySpan<char>.Enumerator GetEnumerator() => new ReadOnlySpan<char>(fields).GetEnumerator();
+    public ReadOnlySpan<char>.Enumerator GetEnumerator() =>
+        (fields is null ? ReadOnlySpan<char>.Empty : new ReadOnlySpan<char>(fields)).GetEnumerator();
 }
 
 /// <summary>
@@ -109,8 +110,9 @@ public readonly record struct CharTemplate :
     public bool Matches(CharTuple tuple) => this.Matches<char, CharTuple, CharTemplate>(tuple);
     public bool Equals(CharTemplate other) => this.SequentialEquals<char, CharTemplate>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TemplateHelpers.ToString(fields);
 
-    public ReadOnlySpan<char?>.Enumerator GetEnumerator() => new ReadOnlySpan<char?>(fields).GetEnumerator();
+    public ReadOnlySpan<char?>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<char?>.Empty : new ReadOnlySpan<char?>(fields)).GetEnumerator();
 }

--- a/src/OrleanSpaces/Tuples/Specialized/DateTimeOffsetTuple.cs
+++ b/src/OrleanSpaces/Tuples/Specialized/DateTimeOffsetTuple.cs
@@ -56,13 +56,14 @@ public readonly record struct DateTimeOffsetTuple :
                    result : this.SequentialEquals<DateTimeOffset, DateTimeOffsetTuple>(other);
     }
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TupleHelpers.ToString(fields);
 
     static DateTimeOffsetTuple ISpaceFactory<DateTimeOffset, DateTimeOffsetTuple>.Create(DateTimeOffset[] fields) => new(fields);
 
     public ReadOnlySpan<char> AsSpan() => this.AsSpan<DateTimeOffset, DateTimeOffsetTuple>(Constants.MaxFieldCharLength_DateTimeOffset);
-    public ReadOnlySpan<DateTimeOffset>.Enumerator GetEnumerator() => new ReadOnlySpan<DateTimeOffset>(fields).GetEnumerator();
+    public ReadOnlySpan<DateTimeOffset>.Enumerator GetEnumerator() =>
+        (fields is null ? ReadOnlySpan<DateTimeOffset>.Empty : new ReadOnlySpan<DateTimeOffset>(fields)).GetEnumerator();
 }
 
 /// <summary>
@@ -99,8 +100,9 @@ public readonly record struct DateTimeOffsetTemplate :
     public bool Matches(DateTimeOffsetTuple tuple) => this.Matches<DateTimeOffset, DateTimeOffsetTuple, DateTimeOffsetTemplate>(tuple);
     public bool Equals(DateTimeOffsetTemplate other) => this.SequentialEquals<DateTimeOffset, DateTimeOffsetTemplate>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TemplateHelpers.ToString(fields);
 
-    public ReadOnlySpan<DateTimeOffset?>.Enumerator GetEnumerator() => new ReadOnlySpan<DateTimeOffset?>(fields).GetEnumerator();
+    public ReadOnlySpan<DateTimeOffset?>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<DateTimeOffset?>.Empty : new ReadOnlySpan<DateTimeOffset?>(fields)).GetEnumerator();
 }

--- a/src/OrleanSpaces/Tuples/Specialized/DateTimeTuple.cs
+++ b/src/OrleanSpaces/Tuples/Specialized/DateTimeTuple.cs
@@ -56,13 +56,14 @@ public readonly record struct DateTimeTuple :
                    result : this.SequentialEquals<DateTime, DateTimeTuple>(other);
     }
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TupleHelpers.ToString(fields);
 
     static DateTimeTuple ISpaceFactory<DateTime, DateTimeTuple>.Create(DateTime[] fields) => new(fields);
 
     public ReadOnlySpan<char> AsSpan() => this.AsSpan<DateTime, DateTimeTuple>(Constants.MaxFieldCharLength_DateTime);
-    public ReadOnlySpan<DateTime>.Enumerator GetEnumerator() => new ReadOnlySpan<DateTime>(fields).GetEnumerator();
+    public ReadOnlySpan<DateTime>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<DateTime>.Empty : new ReadOnlySpan<DateTime>(fields)).GetEnumerator();
 }
 
 /// <summary>
@@ -99,8 +100,9 @@ public readonly record struct DateTimeTemplate :
     public bool Matches(DateTimeTuple tuple) => this.Matches<DateTime, DateTimeTuple, DateTimeTemplate>(tuple);
     public bool Equals(DateTimeTemplate other) => this.SequentialEquals<DateTime, DateTimeTemplate>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TemplateHelpers.ToString(fields);
 
-    public ReadOnlySpan<DateTime?>.Enumerator GetEnumerator() => new ReadOnlySpan<DateTime?>(fields).GetEnumerator();
+    public ReadOnlySpan<DateTime?>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<DateTime?>.Empty : new ReadOnlySpan<DateTime?>(fields)).GetEnumerator();
 }

--- a/src/OrleanSpaces/Tuples/Specialized/DecimalTuple.cs
+++ b/src/OrleanSpaces/Tuples/Specialized/DecimalTuple.cs
@@ -79,13 +79,14 @@ public readonly record struct DecimalTuple :
         return new Comparer(this, other).AllocateAndExecute<int, Comparer>(8 * Length); // 8 x Length, because each decimal will be decomposed into 4 ints, and we have 2 tuples to compare.
     }
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TupleHelpers.ToString(fields);
 
     static DecimalTuple ISpaceFactory<decimal, DecimalTuple>.Create(decimal[] fields) => new(fields);
 
     public ReadOnlySpan<char> AsSpan() => this.AsSpan<decimal, DecimalTuple>(Constants.MaxFieldCharLength_Decimal);
-    public ReadOnlySpan<decimal>.Enumerator GetEnumerator() => new ReadOnlySpan<decimal>(fields).GetEnumerator();
+    public ReadOnlySpan<decimal>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<decimal>.Empty : new ReadOnlySpan<decimal>(fields)).GetEnumerator();
 
     readonly struct Comparer : IBufferConsumer<int>
     {
@@ -151,8 +152,9 @@ public readonly record struct DecimalTemplate :
     public bool Matches(DecimalTuple tuple) => this.Matches<decimal, DecimalTuple, DecimalTemplate>(tuple);
     public bool Equals(DecimalTemplate other) => this.SequentialEquals<decimal, DecimalTemplate>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TemplateHelpers.ToString(fields);
 
-    public ReadOnlySpan<decimal?>.Enumerator GetEnumerator() => new ReadOnlySpan<decimal?>(fields).GetEnumerator();
+    public ReadOnlySpan<decimal?>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<decimal?>.Empty : new ReadOnlySpan<decimal?>(fields)).GetEnumerator();
 }

--- a/src/OrleanSpaces/Tuples/Specialized/DoubleTuple.cs
+++ b/src/OrleanSpaces/Tuples/Specialized/DoubleTuple.cs
@@ -55,13 +55,14 @@ public readonly record struct DoubleTuple :
         => this.TryParallelEquals<double, DoubleTuple>(other, out bool result) ? 
                result : this.SequentialEquals<double, DoubleTuple>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TupleHelpers.ToString(fields);
 
     static DoubleTuple ISpaceFactory<double, DoubleTuple>.Create(double[] fields) => new(fields);
 
     public ReadOnlySpan<char> AsSpan() => this.AsSpan<double, DoubleTuple>(Constants.MaxFieldCharLength_Double);
-    public ReadOnlySpan<double>.Enumerator GetEnumerator() => new ReadOnlySpan<double>(fields).GetEnumerator();
+    public ReadOnlySpan<double>.Enumerator GetEnumerator() =>
+        (fields is null ? ReadOnlySpan<double>.Empty : new ReadOnlySpan<double>(fields)).GetEnumerator();
 }
 
 /// <summary>
@@ -98,8 +99,9 @@ public readonly record struct DoubleTemplate :
     public bool Matches(DoubleTuple tuple) => this.Matches<double, DoubleTuple, DoubleTemplate>(tuple);
     public bool Equals(DoubleTemplate other) => this.SequentialEquals<double, DoubleTemplate>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TemplateHelpers.ToString(fields);
 
-    public ReadOnlySpan<double?>.Enumerator GetEnumerator() => new ReadOnlySpan<double?>(fields).GetEnumerator();
+    public ReadOnlySpan<double?>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<double?>.Empty : new ReadOnlySpan<double?>(fields)).GetEnumerator();
 }

--- a/src/OrleanSpaces/Tuples/Specialized/FloatTuple.cs
+++ b/src/OrleanSpaces/Tuples/Specialized/FloatTuple.cs
@@ -55,13 +55,14 @@ public readonly record struct FloatTuple :
         => this.TryParallelEquals<float, FloatTuple>(other, out bool result) ?
                 result : this.SequentialEquals<float, FloatTuple>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TupleHelpers.ToString(fields);
 
     static FloatTuple ISpaceFactory<float, FloatTuple>.Create(float[] fields) => new(fields);
 
     public ReadOnlySpan<char> AsSpan() => this.AsSpan<float, FloatTuple>(Constants.MaxFieldCharLength_Float);
-    public ReadOnlySpan<float>.Enumerator GetEnumerator() => new ReadOnlySpan<float>(fields).GetEnumerator();
+    public ReadOnlySpan<float>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<float>.Empty : new ReadOnlySpan<float>(fields)).GetEnumerator();
 }
 
 /// <summary>
@@ -98,8 +99,9 @@ public readonly record struct FloatTemplate :
     public bool Matches(FloatTuple tuple) => this.Matches<float, FloatTuple, FloatTemplate>(tuple);
     public bool Equals(FloatTemplate other) => this.SequentialEquals<float, FloatTemplate>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TemplateHelpers.ToString(fields);
 
-    public ReadOnlySpan<float?>.Enumerator GetEnumerator() => new ReadOnlySpan<float?>(fields).GetEnumerator();
+    public ReadOnlySpan<float?>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<float?>.Empty : new ReadOnlySpan<float?>(fields)).GetEnumerator();
 }

--- a/src/OrleanSpaces/Tuples/Specialized/GuidTuple.cs
+++ b/src/OrleanSpaces/Tuples/Specialized/GuidTuple.cs
@@ -80,13 +80,14 @@ public readonly record struct GuidTuple :
         return true;
     }
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TupleHelpers.ToString(fields);
 
     static GuidTuple ISpaceFactory<Guid, GuidTuple>.Create(Guid[] fields) => new(fields);
 
     public ReadOnlySpan<char> AsSpan() => this.AsSpan<Guid, GuidTuple>(Constants.MaxFieldCharLength_Guid);
-    public ReadOnlySpan<Guid>.Enumerator GetEnumerator() => new ReadOnlySpan<Guid>(fields).GetEnumerator();
+    public ReadOnlySpan<Guid>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<Guid>.Empty : new ReadOnlySpan<Guid>(fields)).GetEnumerator();
 }
 
 /// <summary>
@@ -123,8 +124,9 @@ public readonly record struct GuidTemplate :
     public bool Matches(GuidTuple tuple) => this.Matches<Guid, GuidTuple, GuidTemplate>(tuple);
     public bool Equals(GuidTemplate other) => this.SequentialEquals<Guid, GuidTemplate>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TemplateHelpers.ToString(fields);
 
-    public ReadOnlySpan<Guid?>.Enumerator GetEnumerator() => new ReadOnlySpan<Guid?>(fields).GetEnumerator();
+    public ReadOnlySpan<Guid?>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<Guid?>.Empty : new ReadOnlySpan<Guid?>(fields)).GetEnumerator();
 }

--- a/src/OrleanSpaces/Tuples/Specialized/HugeTuple.cs
+++ b/src/OrleanSpaces/Tuples/Specialized/HugeTuple.cs
@@ -68,13 +68,14 @@ public readonly record struct HugeTuple :
         return new Comparer(this, other).AllocateAndExecute<byte, Comparer>(2 * Constants.ByteCount_Int128 * Length);
     }
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TupleHelpers.ToString(fields);
 
     static HugeTuple ISpaceFactory<Int128, HugeTuple>.Create(Int128[] fields) => new(fields);
 
     public ReadOnlySpan<char> AsSpan() => this.AsSpan<Int128, HugeTuple>(Constants.MaxFieldCharLength_Huge);
-    public ReadOnlySpan<Int128>.Enumerator GetEnumerator() => new ReadOnlySpan<Int128>(fields).GetEnumerator();
+    public ReadOnlySpan<Int128>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<Int128>.Empty : new ReadOnlySpan<Int128>(fields)).GetEnumerator();
 
     readonly struct Comparer : IBufferConsumer<byte>
     {
@@ -147,8 +148,9 @@ public readonly record struct HugeTemplate :
     public bool Matches(HugeTuple tuple) => this.Matches<Int128, HugeTuple, HugeTemplate>(tuple);
     public bool Equals(HugeTemplate other) => this.SequentialEquals<Int128, HugeTemplate>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TemplateHelpers.ToString(fields);
 
-    public ReadOnlySpan<Int128?>.Enumerator GetEnumerator() => new ReadOnlySpan<Int128?>(fields).GetEnumerator();
+    public ReadOnlySpan<Int128?>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<Int128?>.Empty : new ReadOnlySpan<Int128?>(fields)).GetEnumerator();
 }

--- a/src/OrleanSpaces/Tuples/Specialized/IntTuple.cs
+++ b/src/OrleanSpaces/Tuples/Specialized/IntTuple.cs
@@ -55,13 +55,14 @@ public readonly record struct IntTuple :
         => this.TryParallelEquals<int, IntTuple>(other, out bool result) ?
                result : this.SequentialEquals<int, IntTuple>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TupleHelpers.ToString(fields);
 
     static IntTuple ISpaceFactory<int, IntTuple>.Create(int[] fields) => new(fields);
 
     public ReadOnlySpan<char> AsSpan() => this.AsSpan<int, IntTuple>(Constants.MaxFieldCharLength_Int);
-    public ReadOnlySpan<int>.Enumerator GetEnumerator() => new ReadOnlySpan<int>(fields).GetEnumerator();
+    public ReadOnlySpan<int>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<int>.Empty : new ReadOnlySpan<int>(fields)).GetEnumerator();
 }
 
 /// <summary>
@@ -98,8 +99,9 @@ public readonly record struct IntTemplate :
     public bool Matches(IntTuple tuple) => this.Matches<int, IntTuple, IntTemplate>(tuple);
     public bool Equals(IntTemplate other) => this.SequentialEquals<int, IntTemplate>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TemplateHelpers.ToString(fields);
 
-    public ReadOnlySpan<int?>.Enumerator GetEnumerator() => new ReadOnlySpan<int?>(fields).GetEnumerator();
+    public ReadOnlySpan<int?>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<int?>.Empty : new ReadOnlySpan<int?>(fields)).GetEnumerator();
 }

--- a/src/OrleanSpaces/Tuples/Specialized/LongTuple.cs
+++ b/src/OrleanSpaces/Tuples/Specialized/LongTuple.cs
@@ -55,13 +55,14 @@ public readonly record struct LongTuple :
         => this.TryParallelEquals<long, LongTuple>(other, out bool result) ?
                result : this.SequentialEquals<long, LongTuple>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TupleHelpers.ToString(fields);
 
     static LongTuple ISpaceFactory<long, LongTuple>.Create(long[] fields) => new(fields);
 
     public ReadOnlySpan<char> AsSpan() => this.AsSpan<long, LongTuple>(Constants.MaxFieldCharLength_Long);
-    public ReadOnlySpan<long>.Enumerator GetEnumerator() => new ReadOnlySpan<long>(fields).GetEnumerator();
+    public ReadOnlySpan<long>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<long>.Empty : new ReadOnlySpan<long>(fields)).GetEnumerator();
 }
 
 /// <summary>
@@ -98,8 +99,9 @@ public readonly record struct LongTemplate :
     public bool Matches(LongTuple tuple) => this.Matches<long, LongTuple, LongTemplate>(tuple);
     public bool Equals(LongTemplate other) => this.SequentialEquals<long, LongTemplate>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TemplateHelpers.ToString(fields);
 
-    public ReadOnlySpan<long?>.Enumerator GetEnumerator() => new ReadOnlySpan<long?>(fields).GetEnumerator();
+    public ReadOnlySpan<long?>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<long?>.Empty : new ReadOnlySpan<long?>(fields)).GetEnumerator();
 }

--- a/src/OrleanSpaces/Tuples/Specialized/SByteTuple.cs
+++ b/src/OrleanSpaces/Tuples/Specialized/SByteTuple.cs
@@ -55,13 +55,14 @@ public readonly record struct SByteTuple :
         => this.TryParallelEquals<sbyte, SByteTuple>(other, out bool result) ?
                result : this.SequentialEquals<sbyte, SByteTuple>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TupleHelpers.ToString(fields);
 
     static SByteTuple ISpaceFactory<sbyte, SByteTuple>.Create(sbyte[] fields) => new(fields);
 
     public ReadOnlySpan<char> AsSpan() => this.AsSpan<sbyte, SByteTuple>(Constants.MaxFieldCharLength_SByte);
-    public ReadOnlySpan<sbyte>.Enumerator GetEnumerator() => new ReadOnlySpan<sbyte>(fields).GetEnumerator();
+    public ReadOnlySpan<sbyte>.Enumerator GetEnumerator() =>
+        (fields is null ? ReadOnlySpan<sbyte>.Empty : new ReadOnlySpan<sbyte>(fields)).GetEnumerator();
 }
 
 /// <summary>
@@ -98,9 +99,10 @@ public readonly record struct SByteTemplate :
     public bool Matches(SByteTuple tuple) => this.Matches<sbyte, SByteTuple, SByteTemplate>(tuple);
     public bool Equals(SByteTemplate other) => this.SequentialEquals<sbyte, SByteTemplate>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TemplateHelpers.ToString(fields);
 
-    public ReadOnlySpan<sbyte?>.Enumerator GetEnumerator() => new ReadOnlySpan<sbyte?>(fields).GetEnumerator();
+    public ReadOnlySpan<sbyte?>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<sbyte?>.Empty : new ReadOnlySpan<sbyte?>(fields)).GetEnumerator();
 }
 

--- a/src/OrleanSpaces/Tuples/Specialized/ShortTuple.cs
+++ b/src/OrleanSpaces/Tuples/Specialized/ShortTuple.cs
@@ -55,13 +55,14 @@ public readonly record struct ShortTuple :
         => this.TryParallelEquals<short, ShortTuple>(other, out bool result) ?
                result : this.SequentialEquals<short, ShortTuple>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TupleHelpers.ToString(fields);
 
     static ShortTuple ISpaceFactory<short, ShortTuple>.Create(short[] fields) => new(fields);
 
     public ReadOnlySpan<char> AsSpan() => this.AsSpan<short, ShortTuple>(Constants.MaxFieldCharLength_Short);
-    public ReadOnlySpan<short>.Enumerator GetEnumerator() => new ReadOnlySpan<short>(fields).GetEnumerator();
+    public ReadOnlySpan<short>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<short>.Empty : new ReadOnlySpan<short>(fields)).GetEnumerator();
 }
 
 /// <summary>
@@ -98,8 +99,9 @@ public readonly record struct ShortTemplate :
     public bool Matches(ShortTuple tuple) => this.Matches<short, ShortTuple, ShortTemplate>(tuple);
     public bool Equals(ShortTemplate other) => this.SequentialEquals<short, ShortTemplate>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TemplateHelpers.ToString(fields);
 
-    public ReadOnlySpan<short?>.Enumerator GetEnumerator() => new ReadOnlySpan<short?>(fields).GetEnumerator();
+    public ReadOnlySpan<short?>.Enumerator GetEnumerator() =>
+        (fields is null ? ReadOnlySpan<short?>.Empty : new ReadOnlySpan<short?>(fields)).GetEnumerator();
 }

--- a/src/OrleanSpaces/Tuples/Specialized/TimeSpanTuple.cs
+++ b/src/OrleanSpaces/Tuples/Specialized/TimeSpanTuple.cs
@@ -56,13 +56,14 @@ public readonly record struct TimeSpanTuple :
                    result : this.SequentialEquals<TimeSpan, TimeSpanTuple>(other);
     }
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TupleHelpers.ToString(fields);
 
     static TimeSpanTuple ISpaceFactory<TimeSpan, TimeSpanTuple>.Create(TimeSpan[] fields) => new(fields);
 
     public ReadOnlySpan<char> AsSpan() => this.AsSpan<TimeSpan, TimeSpanTuple>(Constants.MaxFieldCharLength_TimeSpan);
-    public ReadOnlySpan<TimeSpan>.Enumerator GetEnumerator() => new ReadOnlySpan<TimeSpan>(fields).GetEnumerator();
+    public ReadOnlySpan<TimeSpan>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<TimeSpan>.Empty : new ReadOnlySpan<TimeSpan>(fields)).GetEnumerator();
 }
 
 /// <summary>
@@ -99,8 +100,9 @@ public readonly record struct TimeSpanTemplate :
     public bool Matches(TimeSpanTuple tuple) => this.Matches<TimeSpan, TimeSpanTuple, TimeSpanTemplate>(tuple);
     public bool Equals(TimeSpanTemplate other) => this.SequentialEquals<TimeSpan, TimeSpanTemplate>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TemplateHelpers.ToString(fields);
 
-    public ReadOnlySpan<TimeSpan?>.Enumerator GetEnumerator() => new ReadOnlySpan<TimeSpan?>(fields).GetEnumerator();
+    public ReadOnlySpan<TimeSpan?>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<TimeSpan?>.Empty : new ReadOnlySpan<TimeSpan?>(fields)).GetEnumerator();
 }

--- a/src/OrleanSpaces/Tuples/Specialized/UHugeTuple.cs
+++ b/src/OrleanSpaces/Tuples/Specialized/UHugeTuple.cs
@@ -68,13 +68,14 @@ public readonly record struct UHugeTuple :
         return new Comparer(this, other).AllocateAndExecute<byte, Comparer>(2 * Constants.ByteCount_UInt128 * Length);
     }
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TupleHelpers.ToString(fields);
 
     static UHugeTuple ISpaceFactory<UInt128, UHugeTuple>.Create(UInt128[] fields) => new(fields);
 
     public ReadOnlySpan<char> AsSpan() => this.AsSpan<UInt128, UHugeTuple>(Constants.MaxFieldCharLength_UHuge);
-    public ReadOnlySpan<UInt128>.Enumerator GetEnumerator() => new ReadOnlySpan<UInt128>(fields).GetEnumerator();
+    public ReadOnlySpan<UInt128>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<UInt128>.Empty : new ReadOnlySpan<UInt128>(fields)).GetEnumerator();
 
     readonly struct Comparer : IBufferConsumer<byte>
     {
@@ -147,8 +148,9 @@ public readonly record struct UHugeTemplate :
     public bool Matches(UHugeTuple tuple) => this.Matches<UInt128, UHugeTuple, UHugeTemplate>(tuple);
     public bool Equals(UHugeTemplate other) => this.SequentialEquals<UInt128, UHugeTemplate>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TemplateHelpers.ToString(fields);
 
-    public ReadOnlySpan<UInt128?>.Enumerator GetEnumerator() => new ReadOnlySpan<UInt128?>(fields).GetEnumerator();
+    public ReadOnlySpan<UInt128?>.Enumerator GetEnumerator() =>
+        (fields is null ? ReadOnlySpan<UInt128?>.Empty : new ReadOnlySpan<UInt128?>(fields)).GetEnumerator();
 }

--- a/src/OrleanSpaces/Tuples/Specialized/UIntTuple.cs
+++ b/src/OrleanSpaces/Tuples/Specialized/UIntTuple.cs
@@ -55,13 +55,14 @@ public readonly record struct UIntTuple :
         => this.TryParallelEquals<uint, UIntTuple>(other, out bool result) ?
                result : this.SequentialEquals<uint, UIntTuple>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TupleHelpers.ToString(fields);
 
     static UIntTuple ISpaceFactory<uint, UIntTuple>.Create(uint[] fields) => new(fields);
 
     public ReadOnlySpan<char> AsSpan() => this.AsSpan<uint, UIntTuple>(Constants.MaxFieldCharLength_UInt);
-    public ReadOnlySpan<uint>.Enumerator GetEnumerator() => new ReadOnlySpan<uint>(fields).GetEnumerator();
+    public ReadOnlySpan<uint>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<uint>.Empty : new ReadOnlySpan<uint>(fields)).GetEnumerator();
 }
 
 /// <summary>
@@ -98,8 +99,9 @@ public readonly record struct UIntTemplate :
     public bool Matches(UIntTuple tuple) => this.Matches<uint, UIntTuple, UIntTemplate>(tuple);
     public bool Equals(UIntTemplate other) => this.SequentialEquals<uint, UIntTemplate>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TemplateHelpers.ToString(fields);
 
-    public ReadOnlySpan<uint?>.Enumerator GetEnumerator() => new ReadOnlySpan<uint?>(fields).GetEnumerator();
+    public ReadOnlySpan<uint?>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<uint?>.Empty : new ReadOnlySpan<uint?>(fields)).GetEnumerator();
 }

--- a/src/OrleanSpaces/Tuples/Specialized/ULongTuple.cs
+++ b/src/OrleanSpaces/Tuples/Specialized/ULongTuple.cs
@@ -55,13 +55,14 @@ public readonly record struct ULongTuple :
         => this.TryParallelEquals<ulong, ULongTuple>(other, out bool result) ? 
                result : this.SequentialEquals<ulong, ULongTuple>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TupleHelpers.ToString(fields);
 
     static ULongTuple ISpaceFactory<ulong, ULongTuple>.Create(ulong[] fields) => new(fields);
 
     public ReadOnlySpan<char> AsSpan() => this.AsSpan<ulong, ULongTuple>(Constants.MaxFieldCharLength_ULong);
-    public ReadOnlySpan<ulong>.Enumerator GetEnumerator() => new ReadOnlySpan<ulong>(fields).GetEnumerator();
+    public ReadOnlySpan<ulong>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<ulong>.Empty : new ReadOnlySpan<ulong>(fields)).GetEnumerator();
 }
 
 /// <summary>
@@ -98,8 +99,9 @@ public readonly record struct ULongTemplate :
     public bool Matches(ULongTuple tuple) => this.Matches<ulong, ULongTuple, ULongTemplate>(tuple);
     public bool Equals(ULongTemplate other) => this.SequentialEquals<ulong, ULongTemplate>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TemplateHelpers.ToString(fields);
 
-    public ReadOnlySpan<ulong?>.Enumerator GetEnumerator() => new ReadOnlySpan<ulong?>(fields).GetEnumerator();
+    public ReadOnlySpan<ulong?>.Enumerator GetEnumerator() =>
+        (fields is null ? ReadOnlySpan<ulong?>.Empty : new ReadOnlySpan<ulong?>(fields)).GetEnumerator();
 }

--- a/src/OrleanSpaces/Tuples/Specialized/UShortTuple.cs
+++ b/src/OrleanSpaces/Tuples/Specialized/UShortTuple.cs
@@ -55,13 +55,14 @@ public readonly record struct UShortTuple :
         => this.TryParallelEquals<ushort, UShortTuple>(other, out bool result) ?
                result : this.SequentialEquals<ushort, UShortTuple>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TupleHelpers.ToString(fields);
 
     static UShortTuple ISpaceFactory<ushort, UShortTuple>.Create(ushort[] fields) => new(fields);
 
     public ReadOnlySpan<char> AsSpan() => this.AsSpan<ushort, UShortTuple>(Constants.MaxFieldCharLength_UShort);
-    public ReadOnlySpan<ushort>.Enumerator GetEnumerator() => new ReadOnlySpan<ushort>(fields).GetEnumerator();
+    public ReadOnlySpan<ushort>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<ushort>.Empty : new ReadOnlySpan<ushort>(fields)).GetEnumerator();
 }
 
 /// <summary>
@@ -98,8 +99,9 @@ public readonly record struct UShortTemplate :
     public bool Matches(UShortTuple tuple) => this.Matches<ushort, UShortTuple, UShortTemplate>(tuple);
     public bool Equals(UShortTemplate other) => this.SequentialEquals<ushort, UShortTemplate>(other);
 
-    public override int GetHashCode() => fields.GetHashCode();
+    public override int GetHashCode() => fields?.GetHashCode() ?? 0;
     public override string ToString() => TemplateHelpers.ToString(fields);
 
-    public ReadOnlySpan<ushort?>.Enumerator GetEnumerator() => new ReadOnlySpan<ushort?>(fields).GetEnumerator();
+    public ReadOnlySpan<ushort?>.Enumerator GetEnumerator() => 
+        (fields is null ? ReadOnlySpan<ushort?>.Empty : new ReadOnlySpan<ushort?>(fields)).GetEnumerator();
 }

--- a/tests/OrleanSpaces.Tests/Tuples/BoolTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/BoolTupleTests.cs
@@ -17,6 +17,14 @@ public class BoolTupleTests
     }
 
     [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        BoolTuple tuple = default;
+        Assert.Equal(0, tuple.Length);
+        Assert.True(tuple.IsEmpty);
+    }
+
+    [Fact]
     public void Should_Create_Empty_Tuple_On_Default_Constructor()
     {
         BoolTuple tuple = new();
@@ -129,6 +137,14 @@ public class BoolTemplateTests
     public void Should_Be_Created_On_Empty_Array()
     {
         BoolTemplate template = new(Array.Empty<bool?>());
+        Assert.Equal(1, template.Length);
+        Assert.Null(template[0]);
+    }
+
+    [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        BoolTemplate template = default;
         Assert.Equal(1, template.Length);
         Assert.Null(template[0]);
     }

--- a/tests/OrleanSpaces.Tests/Tuples/BoolTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/BoolTupleTests.cs
@@ -142,11 +142,10 @@ public class BoolTemplateTests
     }
 
     [Fact]
-    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    public void Should_Be_Created_On_Default_Keyword()
     {
         BoolTemplate template = default;
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
+        Assert.Equal(0, template.Length);
     }
 
     [Fact]

--- a/tests/OrleanSpaces.Tests/Tuples/ByteTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/ByteTupleTests.cs
@@ -142,11 +142,10 @@ public class ByteTemplateTests
     }
 
     [Fact]
-    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    public void Should_Be_Created_On_Default_Keyword()
     {
         ByteTemplate template = default;
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
+        Assert.Equal(0, template.Length);
     }
 
     [Fact]

--- a/tests/OrleanSpaces.Tests/Tuples/ByteTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/ByteTupleTests.cs
@@ -17,6 +17,14 @@ public class ByteTupleTests
     }
 
     [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        ByteTuple tuple = default;
+        Assert.Equal(0, tuple.Length);
+        Assert.True(tuple.IsEmpty);
+    }
+
+    [Fact]
     public void Should_Create_Empty_Tuple_On_Default_Constructor()
     {
         ByteTuple tuple = new();
@@ -129,6 +137,14 @@ public class ByteTemplateTests
     public void Should_Be_Created_On_Empty_Array()
     {
         ByteTemplate template = new(Array.Empty<byte?>());
+        Assert.Equal(1, template.Length);
+        Assert.Null(template[0]);
+    }
+
+    [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        ByteTemplate template = default;
         Assert.Equal(1, template.Length);
         Assert.Null(template[0]);
     }

--- a/tests/OrleanSpaces.Tests/Tuples/CharTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/CharTupleTests.cs
@@ -143,11 +143,10 @@ public class CharTemplateTests
     }
 
     [Fact]
-    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    public void Should_Be_Created_On_Default_Keyword()
     {
         CharTemplate template = default;
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
+        Assert.Equal(0, template.Length);
     }
 
     [Fact]

--- a/tests/OrleanSpaces.Tests/Tuples/CharTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/CharTupleTests.cs
@@ -18,6 +18,14 @@ public class CharTupleTests
     }
 
     [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        CharTuple tuple = default;
+        Assert.Equal(0, tuple.Length);
+        Assert.True(tuple.IsEmpty);
+    }
+
+    [Fact]
     public void Should_Create_Empty_Tuple_On_Default_Constructor()
     {
         CharTuple tuple = new();
@@ -130,6 +138,14 @@ public class CharTemplateTests
     public void Should_Be_Created_On_Empty_Array()
     {
         CharTemplate template = new(Array.Empty<char?>());
+        Assert.Equal(1, template.Length);
+        Assert.Null(template[0]);
+    }
+
+    [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        CharTemplate template = default;
         Assert.Equal(1, template.Length);
         Assert.Null(template[0]);
     }

--- a/tests/OrleanSpaces.Tests/Tuples/DateTimeOffsetTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/DateTimeOffsetTupleTests.cs
@@ -152,11 +152,10 @@ public class DateTimeOffsetTemplateTests
     }
 
     [Fact]
-    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    public void Should_Be_Created_On_Default_Keyword()
     {
         DateTimeOffsetTemplate template = default;
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
+        Assert.Equal(0, template.Length);
     }
 
     [Fact]

--- a/tests/OrleanSpaces.Tests/Tuples/DateTimeOffsetTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/DateTimeOffsetTupleTests.cs
@@ -22,6 +22,14 @@ public class DateTimeOffsetTupleTests
     }
 
     [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        DateTimeOffsetTuple tuple = default;
+        Assert.Equal(0, tuple.Length);
+        Assert.True(tuple.IsEmpty);
+    }
+
+    [Fact]
     public void Should_Create_Empty_Tuple_On_Default_Constructor()
     {
         DateTimeOffsetTuple tuple = new();
@@ -139,6 +147,14 @@ public class DateTimeOffsetTemplateTests
     public void Should_Be_Created_On_Empty_Array()
     {
         DateTimeOffsetTemplate template = new(Array.Empty<DateTimeOffset?>());
+        Assert.Equal(1, template.Length);
+        Assert.Null(template[0]);
+    }
+
+    [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        DateTimeOffsetTemplate template = default;
         Assert.Equal(1, template.Length);
         Assert.Null(template[0]);
     }

--- a/tests/OrleanSpaces.Tests/Tuples/DateTimeTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/DateTimeTupleTests.cs
@@ -152,11 +152,10 @@ public class DateTimeTemplateTests
     }
 
     [Fact]
-    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    public void Should_Be_Created_On_Default_Keyword()
     {
         DateTimeTemplate template = default;
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
+        Assert.Equal(0, template.Length);
     }
 
     [Fact]

--- a/tests/OrleanSpaces.Tests/Tuples/DateTimeTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/DateTimeTupleTests.cs
@@ -22,6 +22,14 @@ public class DateTimeTupleTests
     }
 
     [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        DateTimeTuple tuple = default;
+        Assert.Equal(0, tuple.Length);
+        Assert.True(tuple.IsEmpty);
+    }
+
+    [Fact]
     public void Should_Create_Empty_Tuple_On_Default_Constructor()
     {
         DateTimeTuple tuple = new();
@@ -139,6 +147,14 @@ public class DateTimeTemplateTests
     public void Should_Be_Created_On_Empty_Array()
     {
         DateTimeTemplate template = new(Array.Empty<DateTime?>());
+        Assert.Equal(1, template.Length);
+        Assert.Null(template[0]);
+    }
+
+    [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        DateTimeTemplate template = default;
         Assert.Equal(1, template.Length);
         Assert.Null(template[0]);
     }

--- a/tests/OrleanSpaces.Tests/Tuples/DecimalTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/DecimalTupleTests.cs
@@ -142,11 +142,10 @@ public class DecimalTemplateTests
     }
 
     [Fact]
-    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    public void Should_Be_Created_On_Default_Keyword()
     {
         DecimalTemplate template = default;
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
+        Assert.Equal(0, template.Length);
     }
 
     [Fact]

--- a/tests/OrleanSpaces.Tests/Tuples/DecimalTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/DecimalTupleTests.cs
@@ -17,6 +17,14 @@ public class DecimalTupleTests
     }
 
     [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        DecimalTuple tuple = default;
+        Assert.Equal(0, tuple.Length);
+        Assert.True(tuple.IsEmpty);
+    }
+
+    [Fact]
     public void Should_Create_Empty_Tuple_On_Default_Constructor()
     {
         DecimalTuple tuple = new();
@@ -129,6 +137,14 @@ public class DecimalTemplateTests
     public void Should_Be_Created_On_Empty_Array()
     {
         DecimalTemplate template = new(Array.Empty<decimal?>());
+        Assert.Equal(1, template.Length);
+        Assert.Null(template[0]);
+    }
+
+    [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        DecimalTemplate template = default;
         Assert.Equal(1, template.Length);
         Assert.Null(template[0]);
     }

--- a/tests/OrleanSpaces.Tests/Tuples/DoubleTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/DoubleTupleTests.cs
@@ -17,6 +17,14 @@ public class DoubleTupleTests
     }
 
     [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        DoubleTuple tuple = default;
+        Assert.Equal(0, tuple.Length);
+        Assert.True(tuple.IsEmpty);
+    }
+
+    [Fact]
     public void Should_Create_Empty_Tuple_On_Default_Constructor()
     {
         DoubleTuple tuple = new();
@@ -129,6 +137,14 @@ public class DoubleTemplateTests
     public void Should_Be_Created_On_Empty_Array()
     {
         DoubleTemplate template = new(Array.Empty<double?>());
+        Assert.Equal(1, template.Length);
+        Assert.Null(template[0]);
+    }
+
+    [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        DoubleTemplate template = default;
         Assert.Equal(1, template.Length);
         Assert.Null(template[0]);
     }

--- a/tests/OrleanSpaces.Tests/Tuples/DoubleTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/DoubleTupleTests.cs
@@ -142,11 +142,10 @@ public class DoubleTemplateTests
     }
 
     [Fact]
-    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    public void Should_Be_Created_On_Default_Keyword()
     {
         DoubleTemplate template = default;
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
+        Assert.Equal(0, template.Length);
     }
 
     [Fact]

--- a/tests/OrleanSpaces.Tests/Tuples/FloatTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/FloatTupleTests.cs
@@ -134,19 +134,10 @@ public class FloatTemplateTests
     }
 
     [Fact]
-    public void Should_Be_Created_On_Empty_Array()
-    {
-        FloatTemplate template = new(Array.Empty<float?>());
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
-    }
-
-    [Fact]
-    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    public void Should_Be_Created_On_Default_Keyword()
     {
         FloatTemplate template = default;
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
+        Assert.Equal(0, template.Length);
     }
 
     [Fact]

--- a/tests/OrleanSpaces.Tests/Tuples/FloatTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/FloatTupleTests.cs
@@ -17,6 +17,14 @@ public class FloatTupleTests
     }
 
     [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        FloatTuple tuple = default;
+        Assert.Equal(0, tuple.Length);
+        Assert.True(tuple.IsEmpty);
+    }
+
+    [Fact]
     public void Should_Create_Empty_Tuple_On_Default_Constructor()
     {
         FloatTuple tuple = new();
@@ -129,6 +137,14 @@ public class FloatTemplateTests
     public void Should_Be_Created_On_Empty_Array()
     {
         FloatTemplate template = new(Array.Empty<float?>());
+        Assert.Equal(1, template.Length);
+        Assert.Null(template[0]);
+    }
+
+    [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        FloatTemplate template = default;
         Assert.Equal(1, template.Length);
         Assert.Null(template[0]);
     }

--- a/tests/OrleanSpaces.Tests/Tuples/GuidTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/GuidTupleTests.cs
@@ -22,6 +22,14 @@ public class GuidTupleTests
     }
 
     [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        GuidTuple tuple = default;
+        Assert.Equal(0, tuple.Length);
+        Assert.True(tuple.IsEmpty);
+    }
+
+    [Fact]
     public void Should_Create_Empty_Tuple_On_Default_Constructor()
     {
         GuidTuple tuple = new();
@@ -139,6 +147,14 @@ public class GuidTemplateTests
     public void Should_Be_Created_On_Empty_Array()
     {
         GuidTemplate template = new(Array.Empty<Guid?>());
+        Assert.Equal(1, template.Length);
+        Assert.Null(template[0]);
+    }
+
+    [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        GuidTemplate template = default;
         Assert.Equal(1, template.Length);
         Assert.Null(template[0]);
     }

--- a/tests/OrleanSpaces.Tests/Tuples/GuidTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/GuidTupleTests.cs
@@ -152,11 +152,10 @@ public class GuidTemplateTests
     }
 
     [Fact]
-    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    public void Should_Be_Created_On_Default_Keyword()
     {
         GuidTemplate template = default;
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
+        Assert.Equal(0, template.Length);
     }
 
     [Fact]

--- a/tests/OrleanSpaces.Tests/Tuples/HugeTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/HugeTupleTests.cs
@@ -142,11 +142,10 @@ public class HugeTemplateTests
     }
 
     [Fact]
-    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    public void Should_Be_Created_On_Default_Keyword()
     {
         HugeTemplate template = default;
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
+        Assert.Equal(0, template.Length);
     }
 
     [Fact]

--- a/tests/OrleanSpaces.Tests/Tuples/HugeTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/HugeTupleTests.cs
@@ -17,6 +17,14 @@ public class HugeTupleTests
     }
 
     [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        HugeTuple tuple = default;
+        Assert.Equal(0, tuple.Length);
+        Assert.True(tuple.IsEmpty);
+    }
+
+    [Fact]
     public void Should_Create_Empty_Tuple_On_Default_Constructor()
     {
         HugeTuple tuple = new();
@@ -129,6 +137,14 @@ public class HugeTemplateTests
     public void Should_Be_Created_On_Empty_Array()
     {
         HugeTemplate template = new(Array.Empty<Int128?>());
+        Assert.Equal(1, template.Length);
+        Assert.Null(template[0]);
+    }
+
+    [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        HugeTemplate template = default;
         Assert.Equal(1, template.Length);
         Assert.Null(template[0]);
     }

--- a/tests/OrleanSpaces.Tests/Tuples/IntTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/IntTupleTests.cs
@@ -17,6 +17,14 @@ public class IntTupleTests
     }
 
     [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        IntTuple tuple = default;
+        Assert.Equal(0, tuple.Length);
+        Assert.True(tuple.IsEmpty);
+    }
+
+    [Fact]
     public void Should_Create_Empty_Tuple_On_Default_Constructor()
     {
         IntTuple tuple = new();
@@ -129,6 +137,14 @@ public class IntTemplateTests
     public void Should_Be_Created_On_Empty_Array()
     {
         IntTemplate template = new(Array.Empty<int?>());
+        Assert.Equal(1, template.Length);
+        Assert.Null(template[0]);
+    }
+
+    [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        IntTemplate template = default;
         Assert.Equal(1, template.Length);
         Assert.Null(template[0]);
     }

--- a/tests/OrleanSpaces.Tests/Tuples/IntTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/IntTupleTests.cs
@@ -142,11 +142,10 @@ public class IntTemplateTests
     }
 
     [Fact]
-    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    public void Should_Be_Created_On_Default_Keyword()
     {
         IntTemplate template = default;
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
+        Assert.Equal(0, template.Length);
     }
 
     [Fact]

--- a/tests/OrleanSpaces.Tests/Tuples/LongTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/LongTupleTests.cs
@@ -142,11 +142,10 @@ public class LongTemplateTests
     }
 
     [Fact]
-    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    public void Should_Be_Created_On_Default_Keyword()
     {
         LongTemplate template = default;
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
+        Assert.Equal(0, template.Length);
     }
 
     [Fact]

--- a/tests/OrleanSpaces.Tests/Tuples/LongTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/LongTupleTests.cs
@@ -17,6 +17,14 @@ public class LongTupleTests
     }
 
     [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        LongTuple tuple = default;
+        Assert.Equal(0, tuple.Length);
+        Assert.True(tuple.IsEmpty);
+    }
+
+    [Fact]
     public void Should_Create_Empty_Tuple_On_Default_Constructor()
     {
         LongTuple tuple = new();
@@ -129,6 +137,14 @@ public class LongTemplateTests
     public void Should_Be_Created_On_Empty_Array()
     {
         LongTemplate template = new(Array.Empty<long?>());
+        Assert.Equal(1, template.Length);
+        Assert.Null(template[0]);
+    }
+
+    [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        LongTemplate template = default;
         Assert.Equal(1, template.Length);
         Assert.Null(template[0]);
     }

--- a/tests/OrleanSpaces.Tests/Tuples/SByteTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/SByteTupleTests.cs
@@ -142,11 +142,10 @@ public class SByteTemplateTests
     }
 
     [Fact]
-    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    public void Should_Be_Created_On_Default_Keyword()
     {
         SByteTemplate template = default;
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
+        Assert.Equal(0, template.Length);
     }
 
     [Fact]

--- a/tests/OrleanSpaces.Tests/Tuples/SByteTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/SByteTupleTests.cs
@@ -17,6 +17,14 @@ public class SByteTupleTests
     }
 
     [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        SByteTuple tuple = default;
+        Assert.Equal(0, tuple.Length);
+        Assert.True(tuple.IsEmpty);
+    }
+
+    [Fact]
     public void Should_Create_Empty_Tuple_On_Default_Constructor()
     {
         SByteTuple tuple = new();
@@ -129,6 +137,14 @@ public class SByteTemplateTests
     public void Should_Be_Created_On_Empty_Array()
     {
         SByteTemplate template = new(Array.Empty<sbyte?>());
+        Assert.Equal(1, template.Length);
+        Assert.Null(template[0]);
+    }
+
+    [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        SByteTemplate template = default;
         Assert.Equal(1, template.Length);
         Assert.Null(template[0]);
     }

--- a/tests/OrleanSpaces.Tests/Tuples/ShortTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/ShortTupleTests.cs
@@ -142,11 +142,10 @@ public class ShortTemplateTests
     }
 
     [Fact]
-    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    public void Should_Be_Created_On_Default_Keyword()
     {
         ShortTemplate template = default;
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
+        Assert.Equal(0, template.Length);
     }
 
     [Fact]

--- a/tests/OrleanSpaces.Tests/Tuples/ShortTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/ShortTupleTests.cs
@@ -17,6 +17,14 @@ public class ShortTupleTests
     }
 
     [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        ShortTuple tuple = default;
+        Assert.Equal(0, tuple.Length);
+        Assert.True(tuple.IsEmpty);
+    }
+
+    [Fact]
     public void Should_Create_Empty_Tuple_On_Default_Constructor()
     {
         ShortTuple tuple = new();
@@ -129,6 +137,14 @@ public class ShortTemplateTests
     public void Should_Be_Created_On_Empty_Array()
     {
         ShortTemplate template = new(Array.Empty<short?>());
+        Assert.Equal(1, template.Length);
+        Assert.Null(template[0]);
+    }
+
+    [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        ShortTemplate template = default;
         Assert.Equal(1, template.Length);
         Assert.Null(template[0]);
     }

--- a/tests/OrleanSpaces.Tests/Tuples/SpaceTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/SpaceTupleTests.cs
@@ -195,11 +195,10 @@ public class SpaceTemplateTests
     }
 
     [Fact]
-    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    public void Should_Be_Created_On_Default_Keyword()
     {
         SpaceTemplate template = default;
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
+        Assert.Equal(0, template.Length);
     }
 
     [Fact]

--- a/tests/OrleanSpaces.Tests/Tuples/SpaceTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/SpaceTupleTests.cs
@@ -70,6 +70,14 @@ public class SpaceTupleTests
     }
 
     [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        SpaceTuple tuple = default;
+        Assert.Equal(0, tuple.Length);
+        Assert.True(tuple.IsEmpty);
+    }
+
+    [Fact]
     public void Should_Create_Empty_Tuple_On_Default_Constructor()
     {
         SpaceTuple tuple = new();
@@ -182,6 +190,14 @@ public class SpaceTemplateTests
     public void Should_Be_Created_On_Empty_Array()
     {
         SpaceTemplate template = new(Array.Empty<object?>());
+        Assert.Equal(1, template.Length);
+        Assert.Null(template[0]);
+    }
+
+    [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        SpaceTemplate template = default;
         Assert.Equal(1, template.Length);
         Assert.Null(template[0]);
     }

--- a/tests/OrleanSpaces.Tests/Tuples/TimeSpanTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/TimeSpanTupleTests.cs
@@ -22,6 +22,14 @@ public class TimeSpanTupleTests
     }
 
     [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        TimeSpanTuple tuple = default;
+        Assert.Equal(0, tuple.Length);
+        Assert.True(tuple.IsEmpty);
+    }
+
+    [Fact]
     public void Should_Create_Empty_Tuple_On_Default_Constructor()
     {
         TimeSpanTuple tuple = new();
@@ -139,6 +147,14 @@ public class TimeSpanTemplateTests
     public void Should_Be_Created_On_Empty_Array()
     {
         TimeSpanTemplate template = new(Array.Empty<TimeSpan?>());
+        Assert.Equal(1, template.Length);
+        Assert.Null(template[0]);
+    }
+
+    [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        TimeSpanTemplate template = default;
         Assert.Equal(1, template.Length);
         Assert.Null(template[0]);
     }

--- a/tests/OrleanSpaces.Tests/Tuples/TimeSpanTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/TimeSpanTupleTests.cs
@@ -152,11 +152,10 @@ public class TimeSpanTemplateTests
     }
 
     [Fact]
-    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    public void Should_Be_Created_On_Default_Keyword()
     {
         TimeSpanTemplate template = default;
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
+        Assert.Equal(0, template.Length);
     }
 
     [Fact]

--- a/tests/OrleanSpaces.Tests/Tuples/UHugeTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/UHugeTupleTests.cs
@@ -17,6 +17,14 @@ public class UHugeTupleTests
     }
 
     [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        UHugeTuple tuple = default;
+        Assert.Equal(0, tuple.Length);
+        Assert.True(tuple.IsEmpty);
+    }
+
+    [Fact]
     public void Should_Create_Empty_Tuple_On_Default_Constructor()
     {
         UHugeTuple tuple = new();
@@ -129,6 +137,14 @@ public class UHugeTemplateTests
     public void Should_Be_Created_On_Empty_Array()
     {
         UHugeTemplate template = new(Array.Empty<UInt128?>());
+        Assert.Equal(1, template.Length);
+        Assert.Null(template[0]);
+    }
+
+    [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        UHugeTemplate template = default;
         Assert.Equal(1, template.Length);
         Assert.Null(template[0]);
     }

--- a/tests/OrleanSpaces.Tests/Tuples/UHugeTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/UHugeTupleTests.cs
@@ -142,11 +142,10 @@ public class UHugeTemplateTests
     }
 
     [Fact]
-    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    public void Should_Be_Created_On_Default_Keyword()
     {
         UHugeTemplate template = default;
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
+        Assert.Equal(0, template.Length);
     }
 
     [Fact]

--- a/tests/OrleanSpaces.Tests/Tuples/UIntTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/UIntTupleTests.cs
@@ -17,6 +17,14 @@ public class UIntTupleTests
     }
 
     [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        UIntTuple tuple = default;
+        Assert.Equal(0, tuple.Length);
+        Assert.True(tuple.IsEmpty);
+    }
+
+    [Fact]
     public void Should_Create_Empty_Tuple_On_Default_Constructor()
     {
         UIntTuple tuple = new();
@@ -129,6 +137,14 @@ public class UIntTemplateTests
     public void Should_Be_Created_On_Empty_Array()
     {
         UIntTemplate template = new(Array.Empty<uint?>());
+        Assert.Equal(1, template.Length);
+        Assert.Null(template[0]);
+    }
+
+    [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        UIntTemplate template = default;
         Assert.Equal(1, template.Length);
         Assert.Null(template[0]);
     }

--- a/tests/OrleanSpaces.Tests/Tuples/UIntTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/UIntTupleTests.cs
@@ -142,11 +142,10 @@ public class UIntTemplateTests
     }
 
     [Fact]
-    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    public void Should_Be_Created_On_Default_Keyword()
     {
         UIntTemplate template = default;
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
+        Assert.Equal(0, template.Length);
     }
 
     [Fact]

--- a/tests/OrleanSpaces.Tests/Tuples/ULongTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/ULongTupleTests.cs
@@ -17,6 +17,14 @@ public class ULongTupleTests
     }
 
     [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        ULongTuple tuple = default;
+        Assert.Equal(0, tuple.Length);
+        Assert.True(tuple.IsEmpty);
+    }
+
+    [Fact]
     public void Should_Create_Empty_Tuple_On_Default_Constructor()
     {
         ULongTuple tuple = new();
@@ -129,6 +137,14 @@ public class ULongTemplateTests
     public void Should_Be_Created_On_Empty_Array()
     {
         ULongTemplate template = new(Array.Empty<ulong?>());
+        Assert.Equal(1, template.Length);
+        Assert.Null(template[0]);
+    }
+
+    [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        ULongTemplate template = default;
         Assert.Equal(1, template.Length);
         Assert.Null(template[0]);
     }

--- a/tests/OrleanSpaces.Tests/Tuples/ULongTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/ULongTupleTests.cs
@@ -142,11 +142,10 @@ public class ULongTemplateTests
     }
 
     [Fact]
-    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    public void Should_Be_Created_On_Default_Keyword()
     {
         ULongTemplate template = default;
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
+        Assert.Equal(0, template.Length);
     }
 
     [Fact]

--- a/tests/OrleanSpaces.Tests/Tuples/UShortTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/UShortTupleTests.cs
@@ -142,11 +142,10 @@ public class UShortTemplateTests
     }
 
     [Fact]
-    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    public void Should_Be_Created_On_Default_Keyword()
     {
         UShortTemplate template = default;
-        Assert.Equal(1, template.Length);
-        Assert.Null(template[0]);
+        Assert.Equal(0, template.Length);
     }
 
     [Fact]

--- a/tests/OrleanSpaces.Tests/Tuples/UShortTupleTests.cs
+++ b/tests/OrleanSpaces.Tests/Tuples/UShortTupleTests.cs
@@ -17,6 +17,14 @@ public class UShortTupleTests
     }
 
     [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        UShortTuple tuple = default;
+        Assert.Equal(0, tuple.Length);
+        Assert.True(tuple.IsEmpty);
+    }
+
+    [Fact]
     public void Should_Create_Empty_Tuple_On_Default_Constructor()
     {
         UShortTuple tuple = new();
@@ -129,6 +137,14 @@ public class UShortTemplateTests
     public void Should_Be_Created_On_Empty_Array()
     {
         UShortTemplate template = new(Array.Empty<ushort?>());
+        Assert.Equal(1, template.Length);
+        Assert.Null(template[0]);
+    }
+
+    [Fact]
+    public void Should_Create_Empty_Tuple_On_Default_Keyword()
+    {
+        UShortTemplate template = default;
         Assert.Equal(1, template.Length);
         Assert.Null(template[0]);
     }


### PR DESCRIPTION
Fixes #1 - On concurrent environments the creation of the empty tuple via `default` or through LINQ's `FirstOrDefault` returns a default struct which has the `fields` field set to null.